### PR TITLE
disable automatic publish configuration from the gradle development plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,6 +44,7 @@ java {
 }
 
 gradlePlugin {
+    isAutomatedPublishing = false // disable normal plugin publish configuration as long as we publish on MavenCentral
     plugins {
         create("autoconfigure-gradle") {
             id = "io.cloudflight.autoconfigure-gradle"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 kotlin.code.style=official
 
-version=0.1.0
+version=0.1.1
 vendorName=Cloudflight GmbH


### PR DESCRIPTION
* since we publish on Maven-Central for now the automatic configuration is incorrect/unnecessary