### PR TITLE
#6 don't configure the jar task in a lambda in order to maintain execution optimization

### DIFF
--- a/src/main/kotlin/io/cloudflight/gradle/autoconfigure/java/JavaConfigurePlugin.kt
+++ b/src/main/kotlin/io/cloudflight/gradle/autoconfigure/java/JavaConfigurePlugin.kt
@@ -2,8 +2,8 @@ package io.cloudflight.gradle.autoconfigure.java
 
 import io.cloudflight.gradle.autoconfigure.extentions.gradle.api.java.archives.attributes
 import io.cloudflight.gradle.autoconfigure.extentions.gradle.api.plugins.apply
-import io.cloudflight.gradle.autoconfigure.extentions.gradle.api.plugins.getByType
 import io.cloudflight.gradle.autoconfigure.extentions.gradle.api.plugins.create
+import io.cloudflight.gradle.autoconfigure.extentions.gradle.api.plugins.getByType
 import io.cloudflight.gradle.autoconfigure.extentions.gradle.api.tasks.named
 import io.cloudflight.gradle.autoconfigure.extentions.kotlin.collections.contains
 import org.gradle.api.Plugin
@@ -55,12 +55,12 @@ class JavaConfigurePlugin : Plugin<Project> {
             }
 
             val jar = tasks.named(JavaPlugin.JAR_TASK_NAME, Jar::class).get()
-            jar.doFirst {
+            jar.manifest {
                 val configuration = project.configurations.getByName(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME)
                 val classpath = configuration.files.joinToString(" ") { it.name }
                 val createdBy = "${System.getProperty("java.version")} (${System.getProperty("java.vendor")})"
 
-                jar.manifest.attributes(
+                it.attributes(
                     "Class-Path" to classpath,
                     "Created-By" to createdBy,
                     "Implementation-Vendor" to javaConfigureExtension.vendorName.get(),
@@ -83,13 +83,13 @@ class JavaConfigurePlugin : Plugin<Project> {
 
                 if (arrayOf(useJunit, useJunitPlatform, useTestNG).filter { enabled -> enabled }.size > 1) {
                     LOG.warn("Multiple testing frameworks detected in runtime dependencies. No framework enabled automatically. junit4: $useJunit, junit5: $useJunitPlatform, testNg: $useTestNG")
-                } else if(useJunit) {
+                } else if (useJunit) {
                     it.useJUnit()
                     LOG.info("Enabled Junit4 as test platform")
-                } else if(useJunitPlatform) {
+                } else if (useJunitPlatform) {
                     it.useJUnitPlatform()
                     LOG.info("Enabled Junit5 as test platform")
-                } else if(useTestNG) {
+                } else if (useTestNG) {
                     it.useTestNG()
                     LOG.info("Enabled TestNG as test platform")
                 } else {

--- a/src/test/kotlin/io/cloudflight/gradle/autoconfigure/test/util/ProjectFixture.kt
+++ b/src/test/kotlin/io/cloudflight/gradle/autoconfigure/test/util/ProjectFixture.kt
@@ -1,5 +1,6 @@
 package io.cloudflight.gradle.autoconfigure.test.util
 
+import org.assertj.core.api.Assertions.assertThat
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
 import java.nio.file.Path
@@ -18,7 +19,10 @@ internal class ProjectFixture(fixtureBaseDir: Path, val fixtureName: String, val
 
     fun run(first: String, vararg tasks: String): BuildResult {
         val runner = createRunner(first, *tasks, "--stacktrace", "--info", "--rerun-tasks")
-        return runner.build()
+        return runner.build().also {
+            // do some checks that should be true for each biuld
+            assertThat(it.normalizedOutput).doesNotContain("Execution optimizations have been disabled for task")
+        }
     }
 
     fun createRunner(first: String, vararg tasks: String): GradleRunner {


### PR DESCRIPTION
This PR fixes #6 by not using `doFirst` in the `jar` configuration task, this is also being checked now automatically for all test runs