### PR TITLE
use javaToolChain to ensure that we really only use 1.8 compatible code

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,10 +38,18 @@ tasks.test {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
     withSourcesJar()
     withJavadocJar()
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(8))
+    }
+}
+
+tasks.withType<Test> {
+    // we wanna set the java Launcher to 17 here in order to be able set higher java compatibility
+    javaLauncher.set(javaToolchains.launcherFor {
+        languageVersion.set(JavaLanguageVersion.of(17))
+    })
 }
 
 gradlePlugin {
@@ -70,7 +78,8 @@ gradlePlugin {
 
 tasks.withType<Jar>() {
     manifest {
-        val createdBy = "${System.getProperty("java.version")} (${System.getProperty("java.vendor")})"
+        val compiler  = javaToolchains.compilerFor(java.toolchain).get().metadata
+        val createdBy = compiler.javaRuntimeVersion + " (" + compiler.vendor + ")"
         val vendorName: String by project.extra
 
         attributes(

--- a/src/test/kotlin/io/cloudflight/gradle/autoconfigure/AutoconfigureGradlePluginTest.kt
+++ b/src/test/kotlin/io/cloudflight/gradle/autoconfigure/AutoconfigureGradlePluginTest.kt
@@ -6,7 +6,7 @@ import io.cloudflight.gradle.autoconfigure.test.util.normalizedOutput
 import io.cloudflight.gradle.autoconfigure.test.util.useFixture
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import java.nio.file.Path
+import java.nio.file.Paths
 
 class AutoconfigureGradlePluginTest {
 
@@ -42,6 +42,6 @@ class AutoconfigureGradlePluginTest {
 
 }
 
-private val AUTOCONFIGURE_FIXTURE_PATH = Path.of("autoconfigure")
+private val AUTOCONFIGURE_FIXTURE_PATH = Paths.get("autoconfigure")
 private fun <T : Any> autoconfigureFixture(fixtureName: String, gradleVersion: String? = null, testWork: ProjectFixture.() -> T): T =
-    useFixture(AUTOCONFIGURE_FIXTURE_PATH, fixtureName, gradleVersion, testWork)
+        useFixture(AUTOCONFIGURE_FIXTURE_PATH, fixtureName, gradleVersion, testWork)

--- a/src/test/kotlin/io/cloudflight/gradle/autoconfigure/java/JavaConfigurePluginTest.kt
+++ b/src/test/kotlin/io/cloudflight/gradle/autoconfigure/java/JavaConfigurePluginTest.kt
@@ -9,7 +9,7 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.Arguments.arguments
 import org.junit.jupiter.params.provider.MethodSource
-import java.nio.file.Path
+import java.nio.file.Paths
 import java.util.jar.Attributes.Name
 import java.util.jar.Manifest
 import java.util.stream.Stream
@@ -171,9 +171,8 @@ class JavaConfigurePluginTest {
             )
         }
     }
-
 }
 
-private val JAVA_FIXTURE_PATH = Path.of("java")
+private val JAVA_FIXTURE_PATH = Paths.get("java")
 private fun <T : Any> javaFixture(fixtureName: String, gradleVersion: String?, testWork: ProjectFixture.() -> T): T =
         useFixture(JAVA_FIXTURE_PATH, fixtureName, gradleVersion, testWork)

--- a/src/test/kotlin/io/cloudflight/gradle/autoconfigure/test/util/ProjectFixture.kt
+++ b/src/test/kotlin/io/cloudflight/gradle/autoconfigure/test/util/ProjectFixture.kt
@@ -4,8 +4,9 @@ import org.assertj.core.api.Assertions.assertThat
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
 import java.nio.file.Path
+import java.nio.file.Paths
 
-private val FIXTURES_BASE_DIR = Path.of("src", "test", "fixtures")
+private val FIXTURES_BASE_DIR = Paths.get("src", "test", "fixtures")
 
 internal class ProjectFixture(fixtureBaseDir: Path, val fixtureName: String, val gradleVersion: String? = null) {
 


### PR DESCRIPTION
fixed test-code which required Java11