### PR TITLE
Fix issues with TestFramework configuration

### DIFF
--- a/src/main/kotlin/io/cloudflight/gradle/autoconfigure/kotlin/KotlinConfigurePlugin.kt
+++ b/src/main/kotlin/io/cloudflight/gradle/autoconfigure/kotlin/KotlinConfigurePlugin.kt
@@ -54,12 +54,6 @@ class KotlinConfigurePlugin : Plugin<Project> {
             )
         }
 
-        // https://kotlinlang.org/docs/gradle.html#gradle-java-toolchains-support
-        val javaPluginExtension = extensions.getByType(JavaPluginExtension::class)
-        kotlin.jvmToolchain {
-            (it as JavaToolchainSpec).languageVersion.set(javaPluginExtension.toolchain.languageVersion)
-        }
-
         project.afterEvaluate {
             val kotlinVersion = kotlinConfigureExtension.kotlinVersion.get()
             val kotlinMajorMinor = kotlinVersion.toMajorMinor()

--- a/src/test/fixtures/kotlin/single-kotlin-module-constraints/build.gradle
+++ b/src/test/fixtures/kotlin/single-kotlin-module-constraints/build.gradle
@@ -28,15 +28,9 @@ dependencies {
     }
 }
 
-tasks.getByName(JavaPlugin.COMPILE_JAVA_TASK_NAME).doLast {
-    def javaPluginExtension = project.extensions.getByType(JavaPluginExtension)
-    def inferModulePath = javaPluginExtension.hasProperty("modularity") ? javaPluginExtension.modularity.inferModulePath.get() : false
-    logger.quiet("javaPluginExtension.modularity.inferModulePath: {}", inferModulePath)
-    logger.quiet("javaPluginExtension.sourceCompatibility: {}", javaPluginExtension.sourceCompatibility)
-    logger.quiet("javaPluginExtension.targetCompatibility: {}", javaPluginExtension.targetCompatibility)
-    logger.quiet("compileJava.options.encoding: {}", options.encoding)
-}
-
-tasks.getByName(JavaPlugin.COMPILE_TEST_JAVA_TASK_NAME).doLast {
-    logger.quiet("compileTestJava.options.encoding: {}", options.encoding)
+tasks.compileKotlin.doLast {
+    def compiler = javaToolchains.compilerFor {
+        languageVersion.set(project.javaConfigure.languageVersion)
+    }
+    logger.quiet("javaToolchain.jdkHome: {}", compiler.get().metadata.installationPath.asFile.absolutePath)
 }

--- a/src/test/fixtures/kotlin/single-kotlin-module-override-kotlinversion/build.gradle
+++ b/src/test/fixtures/kotlin/single-kotlin-module-override-kotlinversion/build.gradle
@@ -20,15 +20,9 @@ kotlinConfigure {
     kotlinVersion = "1.5.20"
 }
 
-tasks.getByName(JavaPlugin.COMPILE_JAVA_TASK_NAME).doLast {
-    def javaPluginExtension = project.extensions.getByType(JavaPluginExtension)
-    def inferModulePath = javaPluginExtension.hasProperty("modularity") ? javaPluginExtension.modularity.inferModulePath.get() : false
-    logger.quiet("javaPluginExtension.modularity.inferModulePath: {}", inferModulePath)
-    logger.quiet("javaPluginExtension.sourceCompatibility: {}", javaPluginExtension.sourceCompatibility)
-    logger.quiet("javaPluginExtension.targetCompatibility: {}", javaPluginExtension.targetCompatibility)
-    logger.quiet("compileJava.options.encoding: {}", options.encoding)
-}
-
-tasks.getByName(JavaPlugin.COMPILE_TEST_JAVA_TASK_NAME).doLast {
-    logger.quiet("compileTestJava.options.encoding: {}", options.encoding)
+tasks.compileKotlin.doLast {
+    def compiler = javaToolchains.compilerFor {
+        languageVersion.set(project.javaConfigure.languageVersion)
+    }
+    logger.quiet("javaToolchain.jdkHome: {}", compiler.get().metadata.installationPath.asFile.absolutePath)
 }

--- a/src/test/fixtures/kotlin/single-kotlin-module-server/build.gradle
+++ b/src/test/fixtures/kotlin/single-kotlin-module-server/build.gradle
@@ -29,15 +29,9 @@ dependencies {
     }
 }
 
-tasks.getByName(JavaPlugin.COMPILE_JAVA_TASK_NAME).doLast {
-    def javaPluginExtension = project.extensions.getByType(JavaPluginExtension)
-    def inferModulePath = javaPluginExtension.hasProperty("modularity") ? javaPluginExtension.modularity.inferModulePath.get() : false
-    logger.quiet("javaPluginExtension.modularity.inferModulePath: {}", inferModulePath)
-    logger.quiet("javaPluginExtension.sourceCompatibility: {}", javaPluginExtension.sourceCompatibility)
-    logger.quiet("javaPluginExtension.targetCompatibility: {}", javaPluginExtension.targetCompatibility)
-    logger.quiet("compileJava.options.encoding: {}", options.encoding)
-}
-
-tasks.getByName(JavaPlugin.COMPILE_TEST_JAVA_TASK_NAME).doLast {
-    logger.quiet("compileTestJava.options.encoding: {}", options.encoding)
+tasks.compileKotlin.doLast {
+    def compiler = javaToolchains.compilerFor {
+        languageVersion.set(project.javaConfigure.languageVersion)
+    }
+    logger.quiet("javaToolchain.jdkHome: {}", compiler.get().metadata.installationPath.asFile.absolutePath)
 }

--- a/src/test/fixtures/kotlin/single-kotlin-module/build.gradle
+++ b/src/test/fixtures/kotlin/single-kotlin-module/build.gradle
@@ -16,15 +16,9 @@ javaConfigure {
     vendorName = "Cloudflight XYZ"
 }
 
-tasks.getByName(JavaPlugin.COMPILE_JAVA_TASK_NAME).doLast {
-    def javaPluginExtension = project.extensions.getByType(JavaPluginExtension)
-    def inferModulePath = javaPluginExtension.hasProperty("modularity") ? javaPluginExtension.modularity.inferModulePath.get() : false
-    logger.quiet("javaPluginExtension.modularity.inferModulePath: {}", inferModulePath)
-    logger.quiet("javaPluginExtension.sourceCompatibility: {}", javaPluginExtension.sourceCompatibility)
-    logger.quiet("javaPluginExtension.targetCompatibility: {}", javaPluginExtension.targetCompatibility)
-    logger.quiet("compileJava.options.encoding: {}", options.encoding)
-}
-
-tasks.getByName(JavaPlugin.COMPILE_TEST_JAVA_TASK_NAME).doLast {
-    logger.quiet("compileTestJava.options.encoding: {}", options.encoding)
+tasks.compileKotlin.doLast {
+    def compiler = javaToolchains.compilerFor {
+        languageVersion.set(project.javaConfigure.languageVersion)
+    }
+    logger.quiet("javaToolchain.jdkHome: {}", compiler.get().metadata.installationPath.asFile.absolutePath)
 }


### PR DESCRIPTION
* move test framework configuration into an action run directly before the tests run, to avoid to early dependency resolution
* move JavaPlugin configuration outside `afterEvaluate` to enable the user to manipulate those settings
* fix KotlinConfigurePlugin configuring the JavaToolchain.languageVersion Property to use itself as a provider
* add check to Kotlin tests, to ensure the JDK of the JavaToolchain is used during Kotlin compilation

Signed-off-by: Clemens Grabmann <clemens.grabmann@cloudflight.io>