### PR TITLE
revert from using the new JvmTestSuitePlugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ by adding the following block to your `build.gradle.kts`:
 
 ````kotlin
 plugins {
-    id("io.cloudflight.autoconfigure-gradle") version "0.3.0"
+    id("io.cloudflight.autoconfigure-gradle") version "0.4.0"
 }
 ````
 
@@ -65,21 +65,12 @@ The encoding will be set automatically to all source sets, the default being UTF
 
 #### Unit-Test Configuration
 
-The new [JVM Test Suite Plugin](https://docs.gradle.org/current/userguide/jvm_test_suite_plugin.html) is automatically applied
-and configured with `useJUnitPlatform()`.
+The test task is automatically configured with `useJUnitPlatform()` to use the JUnit5 Platform per default. You do need to add the necessary dependencies yourself as described [here](https://docs.gradle.org/current/userguide/java_testing.html#compiling_and_executing_junit_jupiter_tests).
 
-As stated in the official documentation this automatically includes the necessary dependencies with a default version declared by the JVM Test Suite Plugin.
-
-To override the used testing framework or use a different version of the JUnit-Jupiter-Platform use:
+To override the used testing platform use:
 ```kotlin
-testing {
-    suite {
-        val test by getting(JvmTestSuite::class) {
-            useTestNG()
-            // to declare a version
-            useJUnitPlatform("<version>")
-        }
-    }
+tasks.test {
+    useJUnit()
 }
 ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 kotlin.code.style=official
 
-version=0.3.0
+version=0.4.0

--- a/src/main/kotlin/io/cloudflight/gradle/autoconfigure/java/JavaConfigurePlugin.kt
+++ b/src/main/kotlin/io/cloudflight/gradle/autoconfigure/java/JavaConfigurePlugin.kt
@@ -5,7 +5,6 @@ import io.cloudflight.gradle.autoconfigure.extentions.gradle.api.plugins.apply
 import io.cloudflight.gradle.autoconfigure.extentions.gradle.api.plugins.create
 import io.cloudflight.gradle.autoconfigure.extentions.gradle.api.plugins.getByType
 import io.cloudflight.gradle.autoconfigure.extentions.gradle.api.tasks.named
-import io.cloudflight.gradle.autoconfigure.extentions.gradle.api.withType
 import org.gradle.api.Action
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -13,12 +12,10 @@ import org.gradle.api.Task
 import org.gradle.api.plugins.JavaLibraryPlugin
 import org.gradle.api.plugins.JavaPlugin
 import org.gradle.api.plugins.JavaPluginExtension
-import org.gradle.api.plugins.JvmTestSuitePlugin
-import org.gradle.api.plugins.jvm.JvmTestSuite
 import org.gradle.api.tasks.compile.JavaCompile
+import org.gradle.api.tasks.testing.Test
 import org.gradle.jvm.tasks.Jar
 import org.gradle.jvm.toolchain.JavaToolchainService
-import org.gradle.testing.base.TestingExtension
 import org.gradle.testing.jacoco.plugins.JacocoPlugin
 import org.slf4j.LoggerFactory
 
@@ -27,7 +24,6 @@ private const val GRADLE_VERSION = "Gradle-Version"
 class JavaConfigurePlugin : Plugin<Project> {
     override fun apply(project: Project) {
         project.plugins.apply(JavaLibraryPlugin::class)
-        project.plugins.apply(JvmTestSuitePlugin::class)
         project.plugins.apply(JacocoPlugin::class)
 
         val extensions = project.extensions
@@ -48,9 +44,8 @@ class JavaConfigurePlugin : Plugin<Project> {
             it.doFirst(PopulateManifestAction)
         }
 
-        val testingExtension = extensions.getByType(TestingExtension::class)
-        testingExtension.suites.withType(JvmTestSuite::class).configureEach {
-            it.useJUnitJupiter()
+        tasks.named(JavaPlugin.TEST_TASK_NAME, Test::class).configure {
+            it.useJUnitPlatform()
         }
 
         project.afterEvaluate {

--- a/src/test/fixtures/java/single-java-module-junit4/build.gradle
+++ b/src/test/fixtures/java/single-java-module-junit4/build.gradle
@@ -19,12 +19,12 @@ testlogger {
     showFailed false
 }
 
-testing {
-    suites {
-        test {
-            useJUnit()
-        }
-    }
+dependencies {
+    testImplementation("junit:junit:4.13")
+}
+
+tasks.test {
+    useJUnit()
 }
 
 tasks.getByName(JavaPlugin.COMPILE_JAVA_TASK_NAME).doLast {

--- a/src/test/fixtures/java/single-java-module-junit5/build.gradle
+++ b/src/test/fixtures/java/single-java-module-junit5/build.gradle
@@ -19,6 +19,11 @@ testlogger {
     showFailed false
 }
 
+dependencies {
+    testImplementation("org.junit.jupiter:junit-jupiter-api:5.8.1")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.8.1")
+}
+
 tasks.getByName(JavaPlugin.COMPILE_JAVA_TASK_NAME).doLast {
     def javaPluginExtension = project.extensions.getByType(JavaPluginExtension)
     logger.quiet("javaPluginExtension.modularity.inferModulePath: {}", javaPluginExtension.modularity.inferModulePath.get())

--- a/src/test/fixtures/java/single-java-module-testNG/build.gradle
+++ b/src/test/fixtures/java/single-java-module-testNG/build.gradle
@@ -19,12 +19,12 @@ testlogger {
     showFailed false
 }
 
-testing {
-    suites {
-        test {
-            useTestNG()
-        }
-    }
+dependencies {
+    testImplementation("org.testng:testng:7.4.0")
+}
+
+tasks.test {
+    useTestNG()
 }
 
 tasks.getByName(JavaPlugin.COMPILE_JAVA_TASK_NAME).doLast {


### PR DESCRIPTION
revert from using the new JvmTestSuitePlugin since it does not yet provide functionality to override framework versions using a platform