### PR TITLE
Swagger Generation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,6 +42,7 @@ dependencies {
     implementation(libs.spring.boot.plugin)
     implementation(libs.shadow.plugin)
 
+    implementation(libs.swagger.gradle.plugin)
 
     testImplementation(libs.bundles.testImplementationDependencies)
 
@@ -101,6 +102,12 @@ gradlePlugin {
             displayName = "Configure global reports"
             description = "Preconfiguring reports for your build"
             implementationClass = "io.cloudflight.gradle.autoconfigure.report.ReportConfigurePlugin"
+        }
+        create("swagger-api-configure") {
+            id = "io.cloudflight.autoconfigure.swagger-api-configure"
+            displayName = "Configure Swagger Generation"
+            description = "Configure Swagger Generation"
+            implementationClass = "io.cloudflight.gradle.autoconfigure.swagger.SwaggerApiConfigurePlugin"
         }
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,6 +19,9 @@ shadow-plugin = { module = "gradle.plugin.com.github.johnrengelman:shadow", vers
 
 maven-artifact = { module = "org.apache.maven:maven-artifact", version.ref = "maven-artifact" }
 
+# IMPORTANT: do not update, see https://github.com/gigaSproule/swagger-gradle-plugin/issues/186
+swagger-gradle-plugin = { module = "com.benjaminsproule:swagger-gradle-plugin", version = "1.0.8" }
+
 junit-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "jupiter" }
 junit-params = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "jupiter" }
 junit-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "jupiter" }

--- a/src/main/kotlin/io/cloudflight/gradle/autoconfigure/swagger/SwaggerApiConfigurePlugin.kt
+++ b/src/main/kotlin/io/cloudflight/gradle/autoconfigure/swagger/SwaggerApiConfigurePlugin.kt
@@ -20,7 +20,6 @@ import org.gradle.api.tasks.SourceSet
 import org.gradle.internal.classloader.MultiParentClassLoader
 import java.io.File
 import java.net.URLClassLoader
-import java.util.stream.StreamSupport
 
 class SwaggerApiConfigurePlugin : Plugin<Project> {
     override fun apply(target: Project) {
@@ -114,8 +113,7 @@ class SwaggerApiConfigurePlugin : Plugin<Project> {
                     getFilesFromConfiguration(project, JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME),
                     getFilesFromSourceSet(project)
                 )
-                    .stream()
-                    .flatMap { files -> StreamSupport.stream(files.spliterator(), false) }
+                    .flatten()
                     .forEach {
                         val method = classLoader.javaClass.methods.first { it.name == "addURL" }
                         method.invoke(classLoader, it.toURI().toURL())

--- a/src/main/kotlin/io/cloudflight/gradle/autoconfigure/swagger/SwaggerApiConfigurePlugin.kt
+++ b/src/main/kotlin/io/cloudflight/gradle/autoconfigure/swagger/SwaggerApiConfigurePlugin.kt
@@ -1,0 +1,172 @@
+package io.cloudflight.gradle.autoconfigure.swagger
+
+import com.benjaminsproule.swagger.gradleplugin.GenerateSwaggerDocsTask
+import com.benjaminsproule.swagger.gradleplugin.classpath.ClassFinder
+import com.benjaminsproule.swagger.gradleplugin.generator.GeneratorFactory
+import com.benjaminsproule.swagger.gradleplugin.model.ApiSourceExtension
+import com.benjaminsproule.swagger.gradleplugin.model.InfoExtension
+import com.benjaminsproule.swagger.gradleplugin.model.SwaggerExtension
+import com.benjaminsproule.swagger.gradleplugin.reader.ReaderFactory
+import com.benjaminsproule.swagger.gradleplugin.validator.*
+import io.cloudflight.gradle.autoconfigure.java.JavaConfigurePlugin
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.Task
+import org.gradle.api.artifacts.PublishArtifact
+import org.gradle.api.artifacts.dsl.ArtifactHandler
+import org.gradle.api.file.FileCollection
+import org.gradle.api.plugins.JavaPlugin
+import org.gradle.api.plugins.JavaPluginExtension
+import org.gradle.api.tasks.SourceSet
+import org.gradle.internal.classloader.MultiParentClassLoader
+import java.io.File
+import java.net.URLClassLoader
+import java.util.stream.StreamSupport
+
+class SwaggerApiConfigurePlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        target.plugins.apply(JavaConfigurePlugin::class.java)
+
+        val swagger = target.extensions.create(SwaggerExtension.EXTENSION_NAME, SwaggerExtension::class.java, target)
+
+        target.afterEvaluate {
+
+            val jarTask = target.tasks.getByName(JavaPlugin.JAR_TASK_NAME)
+
+            if (swagger.apiSourceExtensions.isNotEmpty()) {
+                with(swagger.apiSourceExtensions.first()) {
+                    info = InfoExtension(target)
+                    info.title = target.name
+                    springmvc = true
+                    outputFormats = listOf("json", "yaml")
+                    swaggerDirectory =
+                        target.layout.buildDirectory.dir("generated/resources/openapi").get().asFile.absolutePath
+                    swaggerFileName = target.name
+                }
+            } else {
+                swagger.apiSourceExtensions.add(ApiSourceExtension(target).apply {
+                    info = InfoExtension(target)
+                    info.title = target.name
+                    springmvc = true
+                    outputFormats = listOf("json", "yaml")
+                    swaggerDirectory =
+                        target.layout.buildDirectory.dir("generated/resources/openapi").get().asFile.absolutePath
+                    swaggerFileName = target.name
+                })
+            }
+
+            val documentationTask =
+                target.tasks.create("clfGenerateSwaggerDocumentation", GenerateSwaggerDocsTask::class.java)
+            val extension = swagger.apiSourceExtensions.first()
+
+            val outputs = extension.outputFormats.map {
+                addSwaggerPublication(
+                    documentationTask,
+                    target.artifacts,
+                    extension.swaggerDirectory,
+                    extension.swaggerFileName,
+                    it
+                )
+            }
+
+            with(documentationTask) {
+                group = "cloudflight" // TODO constant
+                classFinder = ClassFinder(target)
+                readerFactory = ReaderFactory(classFinder, ClassFinder(target, javaClass.classLoader))
+                generatorFactory = GeneratorFactory(classFinder)
+                apiSourceValidator = ApiSourceValidator(
+                    InfoValidator(LicenseValidator()), SecurityDefinitionValidator(
+                        ScopeValidator()
+                    ), TagValidator(ExternalDocsValidator())
+                )
+
+                inputFiles = getFilesFromSourceSet(target)
+                outputDirectories = listOf(target.file(swagger.apiSourceExtensions.first().swaggerDirectory))
+                outputFile = outputs.map { it.file }
+
+                doFirst {
+                    with(extension) {
+                        info.version = project.version.toString()
+                        if (locations == null) {
+                            locations = listOf(
+                                project.group.toString() + ".api",
+                                project.group.toString() + ".api.dto",
+                            )
+                        }
+                    }
+
+                    // Workaround for an issue in the generateSwaggerDocumentation plugin
+                    // check https://github.com/gigaSproule/swagger-gradle-plugin/issues/158#issuecomment-585823379
+                    val classLoader = getUrlClassLoader(target.buildscript.classLoader)
+                    if (classLoader != null) {
+                        listOf(
+                            getFilesFromConfiguration(target, JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME),
+                            getFilesFromConfiguration(target, JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME),
+                            getFilesFromSourceSet(target)
+                        )
+                            .stream()
+                            .flatMap { files -> StreamSupport.stream(files.spliterator(), false) }
+                            .forEach {
+                                val method = classLoader.javaClass.methods.first { it.name == "addURL" }
+                                method.invoke(classLoader, it.toURI().toURL())
+                            }
+                    }
+                }
+            }
+
+            jarTask.dependsOn(documentationTask)
+        }
+    }
+
+    private fun getFilesFromSourceSet(project: Project): FileCollection {
+        val javaPluginExtension = project.extensions.getByType(JavaPluginExtension::class.java)
+        val sourceSetMain = javaPluginExtension.sourceSets.getByName(SourceSet.MAIN_SOURCE_SET_NAME)
+
+        return sourceSetMain.output.classesDirs
+    }
+
+    private fun getFilesFromConfiguration(project: Project, name: String): Set<File> {
+        return project.configurations.getByName(name).files
+    }
+
+    private fun addSwaggerPublication(
+        task: Task,
+        artifacts: ArtifactHandler,
+        targetDir: String,
+        filename: String,
+        format: String
+    ): PublishArtifact {
+        return artifacts.add(
+            JavaPlugin.API_ELEMENTS_CONFIGURATION_NAME,
+            task.project.file("$targetDir/${filename}.${format}")
+        ) {
+            it.name = filename
+            it.classifier = CLASSIFIER
+            it.type = format
+            it.builtBy(task)
+        }
+    }
+
+    private fun getUrlClassLoader(classLoader: ClassLoader?): URLClassLoader? {
+        if (classLoader == null) {
+            return null
+        }
+
+        if (classLoader is URLClassLoader) {
+            return classLoader
+        }
+
+        if (classLoader is MultiParentClassLoader) {
+            classLoader.parents.forEach {
+                val loader = getUrlClassLoader(it)
+                if (loader != null) return loader
+            }
+        }
+
+        return getUrlClassLoader(classLoader.parent)
+    }
+
+    companion object {
+        const val CLASSIFIER = "swagger"
+    }
+}

--- a/src/main/kotlin/io/cloudflight/gradle/autoconfigure/swagger/SwaggerApiConfigurePlugin.kt
+++ b/src/main/kotlin/io/cloudflight/gradle/autoconfigure/swagger/SwaggerApiConfigurePlugin.kt
@@ -34,6 +34,9 @@ class SwaggerApiConfigurePlugin : Plugin<Project> {
             if (swagger.apiSourceExtensions.isEmpty()) {
                 swagger.apiSourceExtensions.add(ApiSourceExtension(target))
             }
+            if (swagger.apiSourceExtensions.size > 1) {
+                throw GradleException("only one apiSource is supported")
+            }
             with(swagger.apiSourceExtensions.first()) {
                 info = InfoExtension(target)
                 info.title = target.name
@@ -52,9 +55,6 @@ class SwaggerApiConfigurePlugin : Plugin<Project> {
             val documentationTask =
                 target.tasks.create("clfGenerateSwaggerDocumentation", GenerateSwaggerDocsTask::class.java)
 
-            if (swagger.apiSourceExtensions.size > 1) {
-                throw GradleException("only one apiSource is supported")
-            }
 
             val extension = swagger.apiSourceExtensions.first()
             val outputs = extension.outputFormats.map {

--- a/src/main/kotlin/io/cloudflight/gradle/autoconfigure/swagger/SwaggerApiConfigurePlugin.kt
+++ b/src/main/kotlin/io/cloudflight/gradle/autoconfigure/swagger/SwaggerApiConfigurePlugin.kt
@@ -118,6 +118,8 @@ class SwaggerApiConfigurePlugin : Plugin<Project> {
                         val method = classLoader.javaClass.methods.first { it.name == "addURL" }
                         method.invoke(classLoader, it.toURI().toURL())
                     }
+            } else {
+                throw GradleException("no classLoader could be found for the buildscript of $project")
             }
         }
 

--- a/src/test/fixtures/swagger/single-swagger-module-override/build.gradle
+++ b/src/test/fixtures/swagger/single-swagger-module-override/build.gradle
@@ -1,0 +1,25 @@
+plugins {
+    id "io.cloudflight.autoconfigure.swagger-api-configure"
+}
+
+repositories {
+    mavenCentral()
+}
+
+description "Cloudflight Gradle Test"
+group "io.cloudflight.gradle"
+version "1.0.0"
+
+swagger {
+    apiSource {
+        swaggerFileName = "myswagger"
+    }
+}
+
+dependencies {
+    implementation 'io.swagger:swagger-annotations:1.6.2'
+    implementation 'org.springframework:spring-web:5.3.16'
+
+    testImplementation("org.junit.jupiter:junit-jupiter-api:5.8.1")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.8.1")
+}

--- a/src/test/fixtures/swagger/single-swagger-module-override/settings.gradle
+++ b/src/test/fixtures/swagger/single-swagger-module-override/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'single-swagger-module-override'

--- a/src/test/fixtures/swagger/single-swagger-module-override/src/main/java/io/cloudflight/gradle/api/FooApi.java
+++ b/src/test/fixtures/swagger/single-swagger-module-override/src/main/java/io/cloudflight/gradle/api/FooApi.java
@@ -1,0 +1,12 @@
+package io.cloudflight.gradle.api;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Api("Foo")
+public interface FooApi {
+
+    @GetMapping("/overview")
+    public String getOverview();
+}

--- a/src/test/fixtures/swagger/single-swagger-module/build.gradle
+++ b/src/test/fixtures/swagger/single-swagger-module/build.gradle
@@ -1,0 +1,19 @@
+plugins {
+    id "io.cloudflight.autoconfigure.swagger-api-configure"
+}
+
+repositories {
+    mavenCentral()
+}
+
+description "Cloudflight Gradle Test"
+group "io.cloudflight.gradle"
+version "1.0.0"
+
+dependencies {
+    implementation 'io.swagger:swagger-annotations:1.6.2'
+    implementation 'org.springframework:spring-web:5.3.16'
+
+    testImplementation("org.junit.jupiter:junit-jupiter-api:5.8.1")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.8.1")
+}

--- a/src/test/fixtures/swagger/single-swagger-module/settings.gradle
+++ b/src/test/fixtures/swagger/single-swagger-module/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'single-swagger-module'

--- a/src/test/fixtures/swagger/single-swagger-module/src/main/java/io/cloudflight/gradle/api/FooApi.java
+++ b/src/test/fixtures/swagger/single-swagger-module/src/main/java/io/cloudflight/gradle/api/FooApi.java
@@ -1,0 +1,12 @@
+package io.cloudflight.gradle.api;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Api("Foo")
+public interface FooApi {
+
+    @GetMapping("/overview")
+    public String getOverview();
+}

--- a/src/test/kotlin/io/cloudflight/gradle/autoconfigure/swagger/SwaggerConfigurePluginTest.kt
+++ b/src/test/kotlin/io/cloudflight/gradle/autoconfigure/swagger/SwaggerConfigurePluginTest.kt
@@ -1,0 +1,56 @@
+package io.cloudflight.gradle.autoconfigure.swagger
+
+import io.cloudflight.gradle.autoconfigure.test.util.ProjectFixture
+import io.cloudflight.gradle.autoconfigure.test.util.normalizedOutput
+import io.cloudflight.gradle.autoconfigure.test.util.useFixture
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.ThrowingConsumer
+import org.gradle.testkit.runner.BuildResult
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.Arguments.arguments
+import org.junit.jupiter.params.provider.MethodSource
+import java.nio.file.Paths
+import java.util.jar.Attributes.Name
+import java.util.jar.Manifest
+import java.util.stream.Stream
+import kotlin.io.path.inputStream
+
+data class TestOptions(
+    val fixtureName: String,
+    val gradleVersion: String? = null,
+)
+
+class KotlinConfigurePluginTest {
+
+
+    @ParameterizedTest
+    @MethodSource("singleSwaggerModuleArguments")
+    fun `the supplied options are used to configure the Swaggerlugin`(
+        options: TestOptions
+    ): Unit = javaFixture(options.fixtureName, options.gradleVersion) {
+        val result = run("clean", "build")
+
+
+        println(result.output)
+    }
+
+    companion object {
+
+        @JvmStatic
+        fun singleSwaggerModuleArguments(): Stream<Arguments> {
+            // keep in sync with the kotlin version in libs.versions.toml
+            return Stream.of(
+                arguments(
+                    TestOptions(
+                        fixtureName = "single-swagger-module",
+                    )
+                )
+            )
+        }
+    }
+}
+
+private val KOTLIN_FIXTURE_PATH = Paths.get("swagger")
+private fun <T : Any> javaFixture(fixtureName: String, gradleVersion: String?, testWork: ProjectFixture.() -> T): T =
+    useFixture(KOTLIN_FIXTURE_PATH, fixtureName, gradleVersion, testWork)

--- a/src/test/kotlin/io/cloudflight/gradle/autoconfigure/swagger/SwaggerConfigurePluginTest.kt
+++ b/src/test/kotlin/io/cloudflight/gradle/autoconfigure/swagger/SwaggerConfigurePluginTest.kt
@@ -16,7 +16,7 @@ data class TestOptions(
     val gradleVersion: String? = null,
 )
 
-class KotlinConfigurePluginTest {
+class SwaggerConfigurePluginTest {
 
 
     @ParameterizedTest

--- a/src/test/kotlin/io/cloudflight/gradle/autoconfigure/swagger/SwaggerConfigurePluginTest.kt
+++ b/src/test/kotlin/io/cloudflight/gradle/autoconfigure/swagger/SwaggerConfigurePluginTest.kt
@@ -1,23 +1,18 @@
 package io.cloudflight.gradle.autoconfigure.swagger
 
 import io.cloudflight.gradle.autoconfigure.test.util.ProjectFixture
-import io.cloudflight.gradle.autoconfigure.test.util.normalizedOutput
 import io.cloudflight.gradle.autoconfigure.test.util.useFixture
 import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.api.ThrowingConsumer
-import org.gradle.testkit.runner.BuildResult
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.Arguments.arguments
 import org.junit.jupiter.params.provider.MethodSource
 import java.nio.file.Paths
-import java.util.jar.Attributes.Name
-import java.util.jar.Manifest
 import java.util.stream.Stream
-import kotlin.io.path.inputStream
 
 data class TestOptions(
     val fixtureName: String,
+    val swaggerFileName: String = fixtureName,
     val gradleVersion: String? = null,
 )
 
@@ -31,8 +26,8 @@ class KotlinConfigurePluginTest {
     ): Unit = javaFixture(options.fixtureName, options.gradleVersion) {
         val result = run("clean", "build")
 
-
-        println(result.output)
+        assertThat(fixtureDir.resolve("build/generated/resources/openapi/${options.swaggerFileName}.json")).exists()
+        assertThat(fixtureDir.resolve("build/generated/resources/openapi/${options.swaggerFileName}.yaml")).exists()
     }
 
     companion object {
@@ -45,6 +40,12 @@ class KotlinConfigurePluginTest {
                     TestOptions(
                         fixtureName = "single-swagger-module",
                     )
+                ),
+                arguments(
+                    TestOptions(
+                        fixtureName = "single-swagger-module-override",
+                        swaggerFileName = "myswagger"
+                    )
                 )
             )
         }
@@ -53,4 +54,4 @@ class KotlinConfigurePluginTest {
 
 private val KOTLIN_FIXTURE_PATH = Paths.get("swagger")
 private fun <T : Any> javaFixture(fixtureName: String, gradleVersion: String?, testWork: ProjectFixture.() -> T): T =
-    useFixture(KOTLIN_FIXTURE_PATH, fixtureName, gradleVersion, testWork)
+    useFixture(KOTLIN_FIXTURE_PATH, fixtureName, gradleVersion, emptyMap(), testWork)


### PR DESCRIPTION
this funcationality is not fully complete yet, but it also does not block us and can already replace some existing code of our internal plugin.
documentation to the readme will be added once we have full support also for code generation. 

compared to the other plugins, the `io.cloudflight.autoconfigure.swagger-api-configure` plugin needs to be applied manually