### PR TITLE
#73 configure the output of npmBuild as output directory instead of a…

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 kotlin.code.style=official
 
-version=0.6.1-SNAPSHOT
+version=0.6.3-SNAPSHOT

--- a/src/main/kotlin/io/cloudflight/gradle/autoconfigure/node/NodeConfigurePlugin.kt
+++ b/src/main/kotlin/io/cloudflight/gradle/autoconfigure/node/NodeConfigurePlugin.kt
@@ -14,8 +14,9 @@ import io.cloudflight.gradle.autoconfigure.util.EnvironmentUtils.isVerifyBuild
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.plugins.JavaPlugin
+import org.gradle.api.plugins.JavaPluginExtension
+import org.gradle.api.tasks.SourceSet
 import org.gradle.language.base.plugins.LifecycleBasePlugin
-import org.gradle.language.jvm.tasks.ProcessResources
 import java.io.File
 
 class NodeConfigurePlugin : Plugin<Project> {
@@ -113,9 +114,11 @@ class NodeConfigurePlugin : Plugin<Project> {
         project.tasks.getByName(JavaPlugin.COMPILE_JAVA_TASK_NAME).mustRunAfter(build)
         project.tasks.getByName(JavaPlugin.JAR_TASK_NAME).dependsOn(build)
 
-        // add the output directory to the JAR
-        project.tasks.named(JavaPlugin.PROCESS_RESOURCES_TASK_NAME, ProcessResources::class.java).get()
-            .from(build.outputs)
+        val javaPluginExtension = project.extensions.getByType(JavaPluginExtension::class.java)
+        val sourceSetMain = javaPluginExtension.sourceSets.getByName(SourceSet.MAIN_SOURCE_SET_NAME)
+
+        sourceSetMain.java.srcDirs(NpmHelper.determineSourceDirs(project))
+        sourceSetMain.output.dir(mapOf("builtBy" to build), nodeExtension.npm.destinationDir)
 
         if (NpmHelper.hasScript("test", project.file(NpmHelper.PACKAGE_JSON))) {
             val npmTest = project.tasks.create("clfNpmTest", NpmTask::class.java) { t ->


### PR DESCRIPTION
…dding it to ProcessResources in order to not clash with buildDev