### PR TITLE
update the license-gradle-plugin

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,14 +14,14 @@ kotlin-noarg = { module = "org.jetbrains.kotlin:kotlin-noarg", version.ref = "ko
 
 jackson = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "jackson" }
 
-license-plugin = { module = "io.cloudflight.license.gradle:license-gradle-plugin", version = "1.0.3" }
+license-plugin = { module = "io.cloudflight.license.gradle:license-gradle-plugin", version = "1.0.4" }
 
 git-properties-plugin = { module = "com.gorylenko.gradle-git-properties:gradle-git-properties", version = "2.4.1" }
 spring-boot-plugin = { module = "org.springframework.boot:spring-boot-gradle-plugin", version = "2.7.1" }
 shadow-plugin = { module = "gradle.plugin.com.github.johnrengelman:shadow", version = "7.1.2" }
 node-plugin = { module = "com.github.node-gradle:gradle-node-plugin", version = "3.4.0" }
 
-json-wrapper = { module = "io.cloudflight.json:json-wrapper", version = "0.3.4" }
+json-wrapper = { module = "io.cloudflight.json:json-wrapper", version = "0.3.5" }
 
 maven-artifact = { module = "org.apache.maven:maven-artifact", version.ref = "maven-artifact" }
 


### PR DESCRIPTION
fixes a bug with optional npm dependencies

Signed-off-by: Klaus Lehner <172195+klu2@users.noreply.github.com>