### PR TITLE
log the auto-application or plugins directly in our AutoConfigurePlugin

### DIFF
--- a/src/test/fixtures/autoconfigure/multi-module-with-root-and-plugin-applied/build.gradle
+++ b/src/test/fixtures/autoconfigure/multi-module-with-root-and-plugin-applied/build.gradle
@@ -7,11 +7,3 @@ group "io.cloudflight.gradle"
 version "1.0.0"
 
 apply plugin: 'java'
-
-project.allprojects { current ->
-    logger.quiet("Project {} start", current.name)
-    current.plugins.forEach {
-        logger.quiet("Plugin {} applied", it.class.name)
-    }
-    logger.quiet("Project {} stop", current.name)
-}

--- a/src/test/fixtures/autoconfigure/multi-module-with-root/build.gradle
+++ b/src/test/fixtures/autoconfigure/multi-module-with-root/build.gradle
@@ -5,11 +5,3 @@ plugins {
 description "Cloudflight Gradle Test"
 group "io.cloudflight.gradle"
 version "1.0.0"
-
-project.allprojects { current ->
-    logger.quiet("Project {} start", current.name)
-    current.plugins.forEach {
-        logger.quiet("Plugin {} applied", it.class.name)
-    }
-    logger.quiet("Project {} stop", current.name)
-}

--- a/src/test/fixtures/autoconfigure/multi-module/build.gradle
+++ b/src/test/fixtures/autoconfigure/multi-module/build.gradle
@@ -6,13 +6,8 @@ description "Cloudflight Gradle Test"
 group "io.cloudflight.gradle"
 version "1.0.0"
 
-project.allprojects { current ->
+allprojects {
     repositories {
         mavenCentral()
     }
-    logger.quiet("Project {} start", current.name)
-    current.plugins.forEach {
-        logger.quiet("Plugin {} applied", it.class.name)
-    }
-    logger.quiet("Project {} stop", current.name)
 }

--- a/src/test/fixtures/autoconfigure/no-autoconfig/build.gradle
+++ b/src/test/fixtures/autoconfigure/no-autoconfig/build.gradle
@@ -5,7 +5,3 @@ plugins {
 description "Cloudflight Gradle Test"
 group "io.cloudflight.gradle"
 version "1.0.0"
-
-plugins.forEach {
-    logger.quiet("Plugin {} applied", it.class.name)
-}

--- a/src/test/fixtures/autoconfigure/single-java-module-autoconfigure/build.gradle
+++ b/src/test/fixtures/autoconfigure/single-java-module-autoconfigure/build.gradle
@@ -6,10 +6,6 @@ description "The JavaConfigurePlugin is automatically applied and the configurat
 group "io.cloudflight.gradle"
 version "1.0.0"
 
-plugins.forEach {
-    logger.quiet("Plugin {} applied", it.class.name)
-}
-
 autoConfigure {
     java {
         languageVersion = JavaLanguageVersion.of(16)

--- a/src/test/fixtures/autoconfigure/single-java-module-configure/build.gradle
+++ b/src/test/fixtures/autoconfigure/single-java-module-configure/build.gradle
@@ -6,10 +6,6 @@ description "The JavaConfigurePlugin is automatically applied and the custom con
 group "io.cloudflight.gradle"
 version "1.0.0"
 
-plugins.forEach {
-    logger.quiet("Plugin {} applied", it.class.name)
-}
-
 javaConfigure {
     languageVersion = JavaLanguageVersion.of(16)
     encoding = "UTF-16"

--- a/src/test/fixtures/autoconfigure/single-java-module-default/build.gradle
+++ b/src/test/fixtures/autoconfigure/single-java-module-default/build.gradle
@@ -6,10 +6,6 @@ description "The JavaConfigurePlugin is automatically applied and the default co
 group "io.cloudflight.gradle"
 version "1.0.0"
 
-plugins.forEach {
-    logger.quiet("Plugin {} applied", it.class.name)
-}
-
 def javaConfigurePluginExtension = project.extensions.getByType(io.cloudflight.gradle.autoconfigure.java.JavaConfigurePluginExtension)
 logger.quiet("javaConfigurePluginExtension.languageVersion: {}", javaConfigurePluginExtension.languageVersion.get())
 logger.quiet("javaConfigurePluginExtension.encoding: {}", javaConfigurePluginExtension.encoding.get())

--- a/src/test/kotlin/io/cloudflight/gradle/autoconfigure/AutoconfigureGradlePluginTest.kt
+++ b/src/test/kotlin/io/cloudflight/gradle/autoconfigure/AutoconfigureGradlePluginTest.kt
@@ -21,8 +21,6 @@ data class TestOptions(
     val applicationBuild: Boolean
 )
 
-private const val s = "java-module"
-
 class AutoconfigureGradlePluginTest {
 
     @Test
@@ -66,18 +64,12 @@ class AutoconfigureGradlePluginTest {
         autoconfigureFixture("multi-module") {
             val result = runTasks()
 
-            val startIndexNoPluginApplied = result.normalizedOutput.indexOf("Project no-plugin-applied start")
-            val endIndexNoPluginApplied =
-                result.normalizedOutput.indexOf("Project no-plugin-applied stop", startIndexNoPluginApplied)
-            val noPluginAppliedOutput =
-                result.normalizedOutput.substring(startIndexNoPluginApplied, endIndexNoPluginApplied)
+            println(result.normalizedOutput)
 
-            val startIndexJavaModule = result.normalizedOutput.indexOf("Project java-module start")
-            val endIndexJavaModule = result.normalizedOutput.indexOf("Project java-module stop", startIndexJavaModule)
-            val javaModuleOutput = result.normalizedOutput.substring(startIndexJavaModule, endIndexJavaModule)
+            assertThat(result.normalizedOutput)
+                .contains("Auto-applied JavaConfigurePlugin to java-module")
+                .doesNotContain("Auto-applied JavaConfigurePlugin to no-plugin-applied")
 
-            assertThat(noPluginAppliedOutput).doesNotContain(JavaConfigurePlugin::class.simpleName)
-            assertThat(javaModuleOutput).contains(JavaConfigurePlugin::class.simpleName)
             println(result.normalizedOutput)
             assertThat(result.normalizedOutput).contains("BUILD EXECUTION TIMES")
         }
@@ -85,7 +77,7 @@ class AutoconfigureGradlePluginTest {
     @Test
     fun `in a multi module project the Autoconfigure plugin automatically propagates the root project version to the subprojects if they don't define it themselves`(): Unit =
         autoconfigureFixture("multi-module") {
-            val result = runCleanBuild()
+            runCleanBuild()
             val javaModule = "java-module"
             val javaModuleJar = this.buildDir(javaModule).resolve("libs/${javaModule}-1.0.0.jar")
             val kotlinModule = "kotlin-module"


### PR DESCRIPTION
By using log statements directly in the AutoConfigurePlugin, we can get rid off some logging statements in our test cases. This makes the test-cases easier to read and we can also use that INFO log later when using the plugin itself, so it is of use for users of the plugin as well.

If you like that, we can do the same for other log-statements (i.e. the final parameters of the JavaConfigExtension) as well.

Signed-off-by: Klaus Lehner <172195+klu2@users.noreply.github.com>