### PR TITLE
fix github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,12 @@ jobs:
         uses: gradle/wrapper-validation-action@v1
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
+      - name : Retrieve module version from Reckon
+        run: echo "VERSION_NAME=$(${{github.workspace}}/gradlew -q clfPrintVersion)" >> $GITHUB_OUTPUT
+        id: retrieve_version
+      - name: Publish module version to Github Step Summary
+        run: |
+          echo "# ${{steps.retrieve_version.outputs.VERSION_NAME}}" >> $GITHUB_STEP_SUMMARY
       - name: Build Plugin
         uses: gradle/gradle-build-action@v2
         with:
@@ -39,17 +45,12 @@ jobs:
         with:
           arguments: check
           cache-read-only: ${{ github.ref != 'refs/heads/main' }}
-      - name : Retrieve Version
-        run: echo "VERSION_NAME=$(${{github.workspace}}/gradlew -q clfPrintVersion)" >> $GITHUB_OUTPUT
-        id: retrieve_version
-      - name: Publish version to Github
-        run: |
-          echo "# ${{steps.retrieve_version.outputs.VERSION_NAME}}" >> $GITHUB_STEP_SUMMARY
       - name: Publish Test Report
-        uses: mikepenz/action-junit-report@v2
+        uses: mikepenz/action-junit-report@v3
         if: always()
         with:
           report_paths: '**/build/test-results/test/TEST-*.xml'
+          include_passed: true
       - name: Publish Artifact
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,23 +42,30 @@ jobs:
           java-version: "17"
       - name: Validate Gradle Wrapper
         uses: gradle/wrapper-validation-action@v1
-      - name: Create Tag
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: check reckonTagPush -Preckon.stage=${{ inputs.stage }} -Preckon.scope=${{ inputs.scope }}
-      - name : Retrieve Version
-        run: echo "VERSION_NAME=$(${{github.workspace}}/gradlew -q clfPrintVersion)" >> $GITHUB_OUTPUT
+      - name: Retrieve module version from Reckon
+        run: echo "VERSION_NAME=$(${{github.workspace}}/gradlew -q clfPrintVersion -Preckon.stage=${{ inputs.stage }} -Preckon.scope=${{ inputs.scope }})" >> $GITHUB_OUTPUT
         id: retrieve_version
-      - name: Publish Plugin
+      - name: Publish module version to Github Step Summary
+        run: |
+          echo "# ${{steps.retrieve_version.outputs.VERSION_NAME}}" >> $GITHUB_STEP_SUMMARY
+      - name: Publish Plugin + Create Tag
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: publishPlugins
+          arguments: check reckonTagPush publishPlugin -Preckon.stage=${{ inputs.stage }} -Preckon.scope=${{ inputs.scope }}
           cache-read-only: true
         env:
           GRADLE_PUBLISH_KEY: ${{ secrets.GRADLE_PUBLISH_KEY }}
           GRADLE_PUBLISH_SECRET: ${{ secrets.GRADLE_PUBLISH_SECRET }}
-      - name: Add artifacts to release
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@v3
+        if: always()
+        with:
+          report_paths: '**/build/test-results/test/TEST-*.xml'
+          include_passed: true
+      - name: Create Release on GitHub
         uses: softprops/action-gh-release@v1
         with:
-          files: build/libs/*.jar
-          token: ${{ secrets.GITHUB_TOKEN }}
+          name: ${{steps.retrieve_version.outputs.VERSION_NAME}}
+          tag_name: ${{steps.retrieve_version.outputs.VERSION_NAME}}
+          generate_release_notes: true
+          append_body: true


### PR DESCRIPTION
This PR applies the GitHub Actions from [JSON-Wrapper](https://github.com/cloudflightio/json-wrapper)

* The task `clfPrintVersion` task is being called at the very beginning (also with the reckon-properties in case of a release). That way we ensure that we are operating on a clean repository, and this is the version that we also use to later automatically create the github release
* The remaining gradle actions (`clean`, `assemble`, `publish`) are being executed atomically within one gradle task in order to assure that all are using the same module version
* The GitHub-Release is created automatically.


**Results:**
* Build Action: https://github.com/cloudflightio/json-wrapper/actions/runs/3408180749
* Publish Action: https://github.com/cloudflightio/json-wrapper/actions/runs/3408181987
* Automatic generated release page:  https://github.com/cloudflightio/json-wrapper/releases/tag/0.5.2
