### PR TITLE
Add autoconfigured "clfNpmClean" task if there is a corresponding npm task

### DIFF
--- a/src/main/kotlin/io/cloudflight/gradle/autoconfigure/node/NodeConfigurePlugin.kt
+++ b/src/main/kotlin/io/cloudflight/gradle/autoconfigure/node/NodeConfigurePlugin.kt
@@ -125,8 +125,10 @@ class NodeConfigurePlugin : Plugin<Project> {
         sourceSetMain.java.srcDirs(NpmHelper.determineSourceDirs(project))
         sourceSetMain.output.dir(mapOf("builtBy" to build), nodeExtension.npm.destinationDir)
 
-        if (NpmHelper.hasScript("test", project.file(NpmHelper.PACKAGE_JSON))) {
-            val npmTest = project.tasks.create("clfNpmTest", NpmTask::class.java) { t ->
+        val packageJson = project.file(NpmHelper.PACKAGE_JSON)
+
+        if (NpmHelper.hasScript("test", packageJson)) {
+            val npmTest = project.tasks.create(NPM_TEST_TASK_NAME, NpmTask::class.java) { t ->
                 t.group = AutoConfigureGradlePlugin.TASK_GROUP
                 t.args.set(listOf("run", "test"))
                 t.dependsOn(listOf(install, build))
@@ -136,11 +138,21 @@ class NodeConfigurePlugin : Plugin<Project> {
             }
             project.tasks.getByName("test").dependsOn(npmTest)
         }
+
+        if (NpmHelper.hasScript("clean", packageJson)) {
+            val npmClean = project.tasks.create(NPM_CLEAN_TASK_NAME, NpmTask::class.java) {                t ->
+                t.group = AutoConfigureGradlePlugin.TASK_GROUP
+                t.args.set(listOf("run", "clean"))
+            }
+            project.tasks.getByName("clean").dependsOn(npmClean)
+        }
     }
 
     companion object {
+        const val NPM_CLEAN_TASK_NAME = "clfNpmClean"
         const val NPM_BUILD_TASK_NAME = "clfNpmBuild"
         const val NPM_LINT_TASK_NAME = "clfNpmLint"
+        const val NPM_TEST_TASK_NAME = "clfNpmTest"
 
         private const val EXTENSION_NAME = "nodeConfigure"
     }

--- a/src/main/kotlin/io/cloudflight/gradle/autoconfigure/node/NodeConfigurePlugin.kt
+++ b/src/main/kotlin/io/cloudflight/gradle/autoconfigure/node/NodeConfigurePlugin.kt
@@ -74,13 +74,13 @@ class NodeConfigurePlugin : Plugin<Project> {
             t.outputs.upToDateWhen { true }
         }
 
-        project.tasks.create("clfNpmBuildDev", NpmTask::class.java) { t ->
+        project.tasks.create(NPM_BUILD_DEV_TASK_NAME, NpmTask::class.java) { t ->
             t.group = AutoConfigureGradlePlugin.TASK_GROUP
             t.args.set(listOf("run", "build:dev"))
             t.dependsOn(install)
         }
 
-        val updateVersion = project.tasks.create("clfNpmUpdateVersion", NpmTask::class.java) { t ->
+        val updateVersion = project.tasks.create(NPM_UPDATE_VERSION_TASK_NAME, NpmTask::class.java) { t ->
             t.group = AutoConfigureGradlePlugin.TASK_GROUP
             t.npmCommand.set(listOf("version"))
             t.args.set(project.provider {
@@ -107,9 +107,9 @@ class NodeConfigurePlugin : Plugin<Project> {
             t.dependsOn(install)
         }
 
-        val packgeJsonFile = project.file(NpmHelper.PACKAGE_JSON)
+        val packageJsonFile = project.file(NpmHelper.PACKAGE_JSON)
 
-        if (isIntegrationBuild() && !isVerifyBuild() && packgeJsonFile.exists()) {
+        if (isIntegrationBuild() && !isVerifyBuild() && packageJsonFile.exists()) {
             install.dependsOn(updateVersion)
         }
 
@@ -151,8 +151,10 @@ class NodeConfigurePlugin : Plugin<Project> {
     companion object {
         const val NPM_CLEAN_TASK_NAME = "clfNpmClean"
         const val NPM_BUILD_TASK_NAME = "clfNpmBuild"
+        const val NPM_BUILD_DEV_TASK_NAME = "clfNpmBuildDev"
         const val NPM_LINT_TASK_NAME = "clfNpmLint"
         const val NPM_TEST_TASK_NAME = "clfNpmTest"
+        const val NPM_UPDATE_VERSION_TASK_NAME = "clfNpmUpdateVersion"
 
         private const val EXTENSION_NAME = "nodeConfigure"
     }


### PR DESCRIPTION
In order to support e.g. cleaning angulars ".angular" cache folder, or any "dist" folder when running "gradle clean", one can add a npm script called "clean", which gets automatically executed whenever the gradle task runs.