### PR TITLE
Add autoconfigured "clfNpmClean" task if there is a corresponding npm script

### DIFF
--- a/src/test/fixtures/node/single-ts-module/package.json
+++ b/src/test/fixtures/node/single-ts-module/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "scripts": {
     "ng": "ng",
+    "clean": "ng cache clean",
     "start": "ng serve",
     "build": "ng build",
     "lint": "ng lint",

--- a/src/test/kotlin/io/cloudflight/gradle/autoconfigure/node/NodeConfigurePluginTest.kt
+++ b/src/test/kotlin/io/cloudflight/gradle/autoconfigure/node/NodeConfigurePluginTest.kt
@@ -68,6 +68,13 @@ class NodeConfigurePluginTest {
                         tasksThatShouldHaveRun = setOf("clfNpmUpdateVersion"),
                         assertUpToDateRerun = false
                     )
+                ),
+                arguments(
+                    TestOptions(
+                        fixtureName = "single-ts-module",
+                        tasksThatShouldHaveRun = setOf("clfNpmClean"),
+                        assertUpToDateRerun = false
+                    )
                 )
             )
         }


### PR DESCRIPTION
In order to support e.g. cleaning angulars ".angular" cache folder, or any "dist" folder when running "gradle clean", one can add a npm script called "clean", which gets automatically executed whenever the gradle task runs.

Signed-off-by: Alexander Hain <alexander.hain@cloudflight.io>