### PR TITLE
#127 apply the JavaPlugin instead of the JavaConfigurePlugin

### DIFF
--- a/src/main/kotlin/io/cloudflight/gradle/autoconfigure/java/JavaConfigurePlugin.kt
+++ b/src/main/kotlin/io/cloudflight/gradle/autoconfigure/java/JavaConfigurePlugin.kt
@@ -28,7 +28,7 @@ import org.springframework.boot.gradle.plugin.SpringBootPlugin
 
 class JavaConfigurePlugin : Plugin<Project> {
     override fun apply(project: Project) {
-        project.plugins.apply(JavaLibraryPlugin::class)
+        project.plugins.apply(JavaPlugin::class)
         project.plugins.apply(JacocoPlugin::class)
 
         if (project.layout.projectDirectory.dir("src/testFixtures").asFile.exists()) {
@@ -45,6 +45,7 @@ class JavaConfigurePlugin : Plugin<Project> {
             applicationBuild.convention(false)
             createSourceArtifacts.convention(applicationBuild.map { !it })
             applicationFramework.convention(ApplicationFramework.SpringBoot)
+            applyApplicationFrameworkPluginForDevelopment.convention(false)
         }
 
         val javaPluginExtension = extensions.getByType(JavaPluginExtension::class)
@@ -69,7 +70,9 @@ class JavaConfigurePlugin : Plugin<Project> {
             if (javaConfigureExtension.applicationBuild.get()){
                 when (javaConfigureExtension.applicationFramework.get()) {
                     ApplicationFramework.SpringBoot -> {
-                        if (BuildUtils.isIntegrationBuild()) {
+                        if (BuildUtils.isIntegrationBuild() ||
+                            javaConfigureExtension.applyApplicationFrameworkPluginForDevelopment.get()
+                        ) {
                             GitExtension.create(project)
                             SpringBootExtension.create(project)
                         } else {
@@ -81,6 +84,8 @@ class JavaConfigurePlugin : Plugin<Project> {
                     }
                     else -> {}
                 }
+            } else {
+                project.plugins.apply(JavaLibraryPlugin::class)
             }
 
             val compileJava = tasks.named(JavaPlugin.COMPILE_JAVA_TASK_NAME, JavaCompile::class)

--- a/src/main/kotlin/io/cloudflight/gradle/autoconfigure/java/JavaConfigurePluginExtension.kt
+++ b/src/main/kotlin/io/cloudflight/gradle/autoconfigure/java/JavaConfigurePluginExtension.kt
@@ -26,6 +26,12 @@ abstract class JavaConfigurePluginExtension {
     abstract val applicationFramework: Property<ApplicationFramework>
 
     /**
+     * if this property is set to `false`, then i.e. the Spring Boot plugin will only
+     * be activated on CI environments
+     */
+    abstract val applyApplicationFrameworkPluginForDevelopment: Property<Boolean>
+
+    /**
      * The version of JDK that is being used to compile Java and Kotlin code.
      * This default is 17.
      */


### PR DESCRIPTION
apply the JavaPlugin instead of the JavaConfigurePlugin for application modules and also provide the possibility to activate the spring boot plugin also locally. I initially thought of setting that default to `true` (i.e. always apply the plugin), but that would be a breaking change in behaviour, so I made it more consistent, giving users the chance to opt-in and probably later make that the default

Signed-off-by: Klaus Lehner <172195+klu2@users.noreply.github.com>