### PR TITLE
patch: update license-gradle-plugin to 1.2.4

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,7 @@ kotlin-noarg = { module = "org.jetbrains.kotlin:kotlin-noarg", version.ref = "ko
 
 jackson = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "jackson" }
 
-license-plugin = { module = "io.cloudflight.license.gradle:license-gradle-plugin", version = "1.2.3" }
+license-plugin = { module = "io.cloudflight.license.gradle:license-gradle-plugin", version = "1.2.4" }
 
 git-properties-plugin = { module = "com.gorylenko.gradle-git-properties:gradle-git-properties", version = "2.4.1" }
 spring-boot-plugin = { module = "org.springframework.boot:spring-boot-gradle-plugin", version = "3.0.1" }


### PR DESCRIPTION
fixing developmentOnly dependencies to be not added to the runtime classpath of the tracker-report

Signed-off-by: Klaus Lehner <172195+klu2@users.noreply.github.com>