### PR TITLE
patch: (#171) add workaround for the gradle task dependencies problem

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,6 +46,7 @@ dependencies {
 
     implementation(libs.springdoc.openapi.plugin)
     implementation(libs.kotlinx.serialization.json)
+    implementation(libs.exec.fork.plugin)
 
     testImplementation(libs.bundles.testImplementationDependencies)
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -38,6 +38,7 @@ swagger-codegen-plugin = { module = "gradle.plugin.org.hidetake:gradle-swagger-g
 swagger-jersey2-jaxrs = { module = "io.swagger:swagger-jersey2-jaxrs", version = { strictly = "1.6.2" } }
 
 springdoc-openapi-plugin = { module = "org.springdoc:springdoc-openapi-gradle-plugin", version = "1.7.0" }
+exec-fork-plugin = { module = "com.github.psxpaul:gradle-execfork-plugin", version = "0.2.0" }
 
 # we need to manually inject this version because of https://github.com/ronmamo/reflections/issues/273 (we would transitively pull 0.9.2 otherwise)
 reflections = { module = "org.reflections:reflections", version = { strictly = "0.9.11" } }

--- a/src/main/kotlin/io/cloudflight/gradle/autoconfigure/extentions/gradle/api/NamedDomainObjectSetExt.kt
+++ b/src/main/kotlin/io/cloudflight/gradle/autoconfigure/extentions/gradle/api/NamedDomainObjectSetExt.kt
@@ -1,6 +1,14 @@
 package io.cloudflight.gradle.autoconfigure.extentions.gradle.api
 
+import org.gradle.api.DomainObjectCollection
+import org.gradle.api.NamedDomainObjectProvider
 import org.gradle.api.NamedDomainObjectSet
 import kotlin.reflect.KClass
 
 internal fun <T : Any, S : T> NamedDomainObjectSet<T>.withType(klass: KClass<S>): NamedDomainObjectSet<S> = this.withType(klass.java)
+
+internal fun <T : Any, S : T> NamedDomainObjectSet<T>.withType(klass: KClass<S>, configuration: (it: S) -> Unit): DomainObjectCollection<S> = this.withType(klass.java, configuration)
+
+internal fun <T: Any, S : T> NamedDomainObjectSet<T>.named(name: String, klass: KClass<S>): NamedDomainObjectProvider<S> = this.named(name, klass.java)
+
+internal fun <T: Any, S : T> NamedDomainObjectSet<T>.named(name: String, klass: KClass<S>, configuration: (it: S) -> Unit): NamedDomainObjectProvider<S> = this.named(name, klass.java, configuration)

--- a/src/main/kotlin/io/cloudflight/gradle/autoconfigure/swagger/SwaggerApiConfigurePlugin.kt
+++ b/src/main/kotlin/io/cloudflight/gradle/autoconfigure/swagger/SwaggerApiConfigurePlugin.kt
@@ -146,13 +146,7 @@ class SwaggerApiConfigurePlugin : Plugin<Project> {
         }
     }
 
-
-
-
-
     companion object {
-
-
         private fun getFilesFromSourceSet(project: Project): FileCollection {
             val javaPluginExtension = project.extensions.getByType(JavaPluginExtension::class.java)
             val sourceSetMain = javaPluginExtension.sourceSets.getByName(SourceSet.MAIN_SOURCE_SET_NAME)

--- a/src/test/fixtures/springdocopenapi/kotlin-springboot-angular/settings.gradle.kts
+++ b/src/test/fixtures/springdocopenapi/kotlin-springboot-angular/settings.gradle.kts
@@ -1,13 +1,5 @@
 import org.ajoberstar.reckon.gradle.ReckonExtension
 
-pluginManagement {
-    repositories {
-        maven {
-            url = uri("https://artifacts.cloudflight.io/repository/plugins-maven")
-        }
-    }
-}
-
 plugins {
     id("io.cloudflight.autoconfigure-settings")
 }

--- a/src/test/fixtures/springdocopenapi/kotlin-springboot-angular/skeleton-server/build.gradle.kts
+++ b/src/test/fixtures/springdocopenapi/kotlin-springboot-angular/skeleton-server/build.gradle.kts
@@ -1,5 +1,12 @@
 plugins {
-   id("io.cloudflight.autoconfigure.springdoc-openapi-configure")
+    id("io.cloudflight.autoconfigure.springdoc-openapi-configure")
+    id("maven-publish")
+}
+
+group = "io.cloudflight.skeleton.angular"
+
+java {
+    withJavadocJar()
 }
 
 dependencies {
@@ -21,10 +28,14 @@ dependencies {
     implementation(libs.springdoc.openapi.starter.webmvc.api)
 }
 
-tasks.named("forkedSpringBootRun") {
-    doNotTrackState("We cannot track the state during the test since the working directory is already blocked by the test-executing gradle-process.")
-}
-
 openApi {
     outputFileName.set("custom-openapi.json")
+}
+
+publishing {
+    publications {
+        create<MavenPublication>("maven") {
+            from(components.getByName("java"))
+        }
+    }
 }

--- a/src/test/kotlin/io/cloudflight/gradle/autoconfigure/springdocopenapi/SpringDocOpenApiConfigurePluginTest.kt
+++ b/src/test/kotlin/io/cloudflight/gradle/autoconfigure/springdocopenapi/SpringDocOpenApiConfigurePluginTest.kt
@@ -1,6 +1,7 @@
 package io.cloudflight.gradle.autoconfigure.springdocopenapi
 
 import io.cloudflight.gradle.autoconfigure.test.util.ProjectFixture
+import io.cloudflight.gradle.autoconfigure.test.util.normalizedOutput
 import io.cloudflight.gradle.autoconfigure.test.util.useFixture
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -17,11 +18,10 @@ class SpringDocOpenApiConfigurePluginTest {
         assertThat(buildDir().resolve("generated/resources/openapi/springdoc-openapi.yaml")).exists()
     }
 
-
     @Test
     fun `the openapi document is created in a multi module project`():
             Unit = springdocFixture("kotlin-springboot-angular") {
-        val result = run("clfGenerateOpenApiDocumentation")
+        val result = run("publishToMavenLocal")
 
         assertThat(buildDir("skeleton-server").resolve("generated/resources/openapi/custom-openapi.json")).exists()
         assertThat(buildDir("skeleton-server").resolve("generated/resources/openapi/custom-openapi.yaml")).exists()


### PR DESCRIPTION
* we work around this by creating a dummy directory which we will use as a working directory for the forked spring bootRun task. Because some other tasks also seem to use this directory we also make them depend on this task. But that list might be incomplete.